### PR TITLE
Fix branch name in CI configuration

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
     tags: ['*']
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
You're referring to the wrong branch name in your CI script. I suspect that why your coverage is showing as "0", cf. #6